### PR TITLE
fix next node is unknown when laravel call remote with guzzle.

### DIFF
--- a/lib/Pinpoint/Plugins/AutoGen/GuzzleHttp/GuzzlePlugin.php
+++ b/lib/Pinpoint/Plugins/AutoGen/GuzzleHttp/GuzzlePlugin.php
@@ -26,7 +26,7 @@ class GuzzlePlugin extends PinTrace
     function onBefore()
     {
         if(strpos($this->apId, "Request::__construct") !== false){
-            pinpoint_add_clue(PP_DESTINATION,CurlUtil::getHostFromURL($this->args[1]->getHost()));
+            pinpoint_add_clue(PP_DESTINATION,CurlUtil::getHostFromURL((string)($this->args[1])));
             pinpoint_add_clues(PP_HTTP_URL,$this->args[1]);
             pinpoint_add_clue(PP_SERVER_TYPE,PP_PHP_REMOTE);
 

--- a/lib/Pinpoint/Plugins/Sys/curl/CurlUtil.php
+++ b/lib/Pinpoint/Plugins/Sys/curl/CurlUtil.php
@@ -105,11 +105,6 @@ class CurlUtil
             $retUrl.=$urlAr['host'];
         }
 
-        if(isset($urlAr['path']))
-        {
-            $retUrl.= $urlAr['path'];
-        }
-
         if(isset($urlAr['port'])) // an optional setting
         {
             $retUrl .= ":".$urlAr['port'];


### PR DESCRIPTION
fix next node is unknown when laravel call remote with guzzle.